### PR TITLE
adds threshold, expire, and executeAutomatically to multisigSubmit

### DIFF
--- a/src/network/modules/account/__tests__/account.test.ts
+++ b/src/network/modules/account/__tests__/account.test.ts
@@ -93,6 +93,9 @@ describe("Account", () => {
       from: "m321",
       symbol: "m456",
       memo: "this is a memo",
+      executeAutomatically: false,
+      threshold: 3,
+      expireInSecs: 3600,
     }
 
     const res = await account.submitMultisigTxn(EventType.send, txnData, opts)
@@ -106,6 +109,9 @@ describe("Account", () => {
           .set(0, eventTypeNameToIndices[EventType.send])
           .set(1, makeLedgerSendParam(txnData)),
       )
+      .set(3, 3)
+      .set(4, 3600)
+      .set(5, false)
     expect(mockCall).toHaveBeenCalledWith(
       "account.multisigSubmitTransaction",
       expectedCallArgs,


### PR DESCRIPTION
<!-- Provide a general summary of changes in the title above. -->

## Description

- `account.submitMultisigTxn` now accepts approver threshold, expire, and execute automatically flag so that each transaction can have this customized.

<!-- Please describe your change in detail. -->
<!-- What is the current behavior and what is the new behavior? -->

## Related Issue

<!-- Pull Requests should relate to an open Issue. -->
<!-- If this PR fixes a bug or introduces a new feature, please create an Issue first. -->

Fixes https://github.com/liftedinit/many-js/issues/54

## Testing

- jest test updated
<!-- Please describe how you tested your changes. -->
<!-- Include details of your testing environment and the tests you ran. -->

## Checklist:

- [x] I have read and followed the CONTRIBUTING guidelines for this project.
- [x] I have added or updated tests and they pass.
