### PR TITLE
fix missing decoders in Message

### DIFF
--- a/src/message/cose.ts
+++ b/src/message/cose.ts
@@ -11,6 +11,14 @@ import { CborData, CborMap, tag } from "./cbor"
 
 export const ANONYMOUS = Buffer.from([0x00])
 export const EMPTY = Buffer.alloc(0)
+
+export const decoders = {
+  tags: {
+    10000: (value: Uint8Array) => new Address(Buffer.from(value)),
+    1: (value: number) => tag(1, value),
+  },
+}
+
 export class CoseMessage {
   protectedHeader: CborMap
   unprotectedHeader: CborMap
@@ -30,12 +38,6 @@ export class CoseMessage {
   }
 
   static fromCborData(data: CborData): CoseMessage {
-    const decoders = {
-      tags: {
-        10000: (value: Uint8Array) => new Address(Buffer.from(value)),
-        1: (value: number) => tag(1, value),
-      },
-    }
     const cose = cbor.decodeFirstSync(data, decoders).value
     const protectedHeader = cbor.decodeFirstSync(cose[0])
     const unprotectedHeader = cose[1]

--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -1,7 +1,7 @@
 import cbor from "cbor";
 import { Address, Identity } from "../identity"
 import { CborData, CborMap, tag } from "./cbor";
-import { CoseMessage } from "./cose";
+import { CoseMessage, decoders } from "./cose";
 import { ManyError, SerializedManyError } from "./error";
 import { Attributes, AsyncAttribute } from "./attributes"
 
@@ -35,7 +35,7 @@ export class Message {
   }
 
   getPayload(): CborMap {
-    return cbor.decode(this.content?.get(4))
+    return cbor.decode(this.content?.get(4), decoders)
   }
 
   static fromObject(obj: MessageContent): Message {

--- a/src/network/modules/account/__tests__/account.test.ts
+++ b/src/network/modules/account/__tests__/account.test.ts
@@ -34,8 +34,8 @@ describe("Account", () => {
     roles.set(identityStr3, [AccountRole.canMultisigApprove])
     const _roles = Array.from(roles).reduce((acc, rolesForAddress) => {
       const [address, roleList] = rolesForAddress
-      const bytes = Address.fromString(address).toBuffer()
-      acc.set({ value: bytes }, roleList)
+      const taggedIdentity = tag(10000, Address.fromString(address).toBuffer())
+      acc.set(taggedIdentity, roleList)
       return acc
     }, new Map())
     const features: AccountFeature[] = [
@@ -123,7 +123,7 @@ describe("Account", () => {
   })
 
   it("multisigInfo() should return info about the multisig transaction", async () => {
-    const expireDate = new Date(new Date().getTime() + ONE_MINUTE)
+    const expireDate = new Date(new Date().getTime() + ONE_MINUTE).getTime()
     const mockCall = jest.fn(async () => {
       return makeMockResponseMessage(
         makeMultisigInfoResponse({
@@ -335,7 +335,7 @@ function makeMultisigInfoResponse({
   expireDate,
   txnState,
 }: {
-  expireDate: Date
+  expireDate: number
   txnState: MultisigTransactionState
 }) {
   const accountMultisigTxn = new Map().set(0, eventTypeNameToIndices.send).set(
@@ -358,7 +358,7 @@ function makeMultisigInfoResponse({
     .set(3, approvers)
     .set(4, threshold)
     .set(5, executeAutomatically)
-    .set(6, expireDate)
+    .set(6, tag(1, expireDate))
     .set(7, null)
     .set(8, txnState)
 }

--- a/src/network/modules/async/async.ts
+++ b/src/network/modules/async/async.ts
@@ -3,6 +3,7 @@ import { ONE_MINUTE, ONE_SECOND } from "../../../const"
 import { AnonymousIdentity } from "../../../identity"
 import { Message } from "../../../message"
 import { CborMap } from "../../../message/cbor"
+import { decoders } from "../../../message/cose"
 import { throwOnErrorResponse } from "../../../utils"
 import { Network } from "../../network"
 import type { NetworkModule } from "../types"
@@ -82,7 +83,7 @@ async function pollAsyncStatus(
     switch (result.result) {
       case AsyncStatusResult.Done:
         return throwOnErrorResponse(
-          new Message(cbor.decode(result.payload).value),
+          new Message(cbor.decode(result.payload, decoders).value),
         )
       case AsyncStatusResult.Expired:
         throw new Error("Async Expired before getting a result")

--- a/src/network/modules/base/base.ts
+++ b/src/network/modules/base/base.ts
@@ -1,6 +1,5 @@
 import cbor from "cbor"
 import { Message } from "../../../message"
-import { getAddressFromTaggedIdentity } from "../../../utils"
 import { NetworkModule, NetworkAttributes } from "../types"
 
 export interface Base extends NetworkModule {
@@ -58,7 +57,7 @@ async function getNetworkStatus(msg: Message): Promise<NetworkStatusResponse> {
       protocolVersion: content.get(0),
       serverName: content.get(1),
       publicKey,
-      address: await getAddressFromTaggedIdentity(content.get(3)),
+      address: content.get(3)?.toString(),
       attributes: content.get(4),
       serverVersion: content.get(5),
       timeDeltaInSecs: content.get(7),

--- a/src/network/modules/events/__tests__/data.ts
+++ b/src/network/modules/events/__tests__/data.ts
@@ -36,9 +36,8 @@ export const expectedMockEventInfoResponse = {
   events: [EventType.send, EventType.accountCreate],
 }
 
-const eventTime1 = new Date()
-const eventTime2 = new Date()
-eventTime2.setMinutes(eventTime1.getMinutes() + 1)
+const eventTime1 = new Date().getTime()
+const eventTime2 = eventTime1 + 60000
 
 const sendTxn1 = makeSendTxn({
   id: 1,
@@ -96,7 +95,7 @@ function makeMultisigSubmitTxnResponse({
   threshold,
   executeAutomatically = false,
   cborData,
-  expireDate = new Date(new Date().getTime() + ONE_MINUTE),
+  expireDate = new Date(new Date().getTime() + ONE_MINUTE).getTime(),
   time,
 }: {
   id: number
@@ -109,8 +108,8 @@ function makeMultisigSubmitTxnResponse({
   threshold: number
   executeAutomatically: boolean
   cborData?: Map<number, unknown>
-  expireDate?: Date
-  time: Date
+  expireDate?: number
+  time: number
 }) {
   const m = new Map()
   m.set(0, txnTypeIndices)
@@ -120,7 +119,7 @@ function makeMultisigSubmitTxnResponse({
     .set(4, submittedTxn)
     .set(5, token)
     .set(6, threshold)
-    .set(7, expireDate)
+    .set(7, tag(1, expireDate))
     .set(8, executeAutomatically)
     .set(9, cborData)
 
@@ -140,7 +139,7 @@ function makeMultisigTxnResponse({
   accountSource: string
   token?: ArrayBuffer
   actor: string
-  time: Date
+  time: number
 }) {
   const m = new Map()
     .set(2, token)
@@ -163,22 +162,22 @@ function makeTxn({
   txnData,
 }: {
   id: number
-  time: Date
+  time: number
   txnData: Map<number, unknown>
 }) {
-  return new Map().set(0, id).set(1, time).set(2, txnData)
+  return new Map().set(0, id).set(1, tag(1, time)).set(2, txnData)
 }
 
 function makeSendTxn({
   id,
-  time = new Date(),
+  time = new Date().getTime(),
   source,
   destination,
   symbol,
   amount,
 }: {
   id: number
-  time?: Date
+  time?: number
   source: string
   destination: string
   symbol: string
@@ -198,7 +197,7 @@ function makeEventsListResponseMessage(count: number, events: unknown[]) {
   return makeMockResponseMessage(new Map().set(0, count).set(1, events))
 }
 
-const expireDate = new Date(new Date().getTime() + ONE_MINUTE)
+const expireDate = new Date(new Date().getTime() + ONE_MINUTE).getTime()
 export const mockEventsListMultisigSubmitEventResponse =
   makeEventsListResponseMessage(1, [
     makeMultisigSubmitTxnResponse({
@@ -454,8 +453,8 @@ roles.set(identityStr3, [AccountRole.canMultisigApprove])
 
 const _roles = Array.from(roles).reduce((acc, rolesForAddress) => {
   const [address, roleList] = rolesForAddress
-  const bytes = Address.fromString(address).toBuffer()
-  acc.set({ value: bytes }, roleList)
+  const bytes = tag(10000, Address.fromString(address).toBuffer())
+  acc.set(bytes, roleList)
   return acc
 }, new Map())
 
@@ -476,7 +475,7 @@ function makeAccountCreateTxnResponse({
   accountSource,
 }: {
   id: number
-  time: Date
+  time: number
   accountName: string
   accountSource: string
 }) {

--- a/src/network/modules/events/__tests__/events.test.ts
+++ b/src/network/modules/events/__tests__/events.test.ts
@@ -1,11 +1,6 @@
-import {
-  Events,
-  makeListFilters,
-  OrderType,
-  BoundType,
-  setRangeBound,
-  RangeType,
-} from "../events"
+import { setRangeBound } from "../../../../utils"
+import { BoundType, ListOrderType } from "../../types"
+import { Events, makeListFilters, RangeType } from "../events"
 import {
   mockEventsListSendTxnResponseMessage,
   expectedMockEventsListSendResponse,
@@ -86,7 +81,7 @@ describe("Events", () => {
       mockCall.mockResolvedValueOnce(mockEventsListSendTxnResponseMessage)
       const txnId = new Uint8Array(Buffer.from("txn"))
       await events.list({
-        order: OrderType.ascending,
+        order: ListOrderType.ascending,
         count: 20,
         filters: {
           symbols: "symbol1",
@@ -102,7 +97,7 @@ describe("Events", () => {
         // @ts-ignore
         new Map([
           [0, 20],
-          [1, OrderType.ascending],
+          [1, ListOrderType.ascending],
           [
             2,
             // @ts-ignore

--- a/src/network/modules/events/index.ts
+++ b/src/network/modules/events/index.ts
@@ -1,4 +1,4 @@
-export { Events, BoundType, OrderType } from "./events"
+export { Events } from "./events"
 export type {
   ListFilterArgs,
   Event,

--- a/src/network/modules/ledger/ledger.ts
+++ b/src/network/modules/ledger/ledger.ts
@@ -1,4 +1,3 @@
-import { Address } from "../../../identity"
 import { Message } from "../../../message"
 import { makeLedgerSendParam, makeRandomBytes } from "../../../utils"
 import { LedgerSendParam, NetworkModule } from "../types"
@@ -56,7 +55,7 @@ export function getLedgerInfo(message: Message): LedgerInfo {
       const symbols = decodedContent.get(4)
 
       for (const symbol of symbols) {
-        const address = new Address(Buffer.from(symbol[0].value)).toString()
+        const address = symbol[0].toString()
         const symbolName = symbol[1]
         result.symbols.set(address, symbolName)
       }
@@ -76,7 +75,7 @@ export function getBalance(message: Message): Balances {
     const symbolsToBalancesMap = messageContent.get(0)
     if (!(symbolsToBalancesMap instanceof Map)) return result
     for (const balanceEntry of symbolsToBalancesMap) {
-      const symbolAddress = new Address(balanceEntry[0].value).toString()
+      const symbolAddress = balanceEntry[0].toString()
       const balance = balanceEntry[1]
       result.balances.set(symbolAddress, balance)
     }

--- a/src/network/modules/test/test-utils.ts
+++ b/src/network/modules/test/test-utils.ts
@@ -11,10 +11,13 @@ export const Address1 = Address.fromString(identityStr1).toBuffer()
 export const identityStr2 = "maffbahksdwaqeenayy2gxke32hgb7aq4ao4wt745lsfs6wijp"
 export const Address2 = Address.fromString(identityStr2).toBuffer()
 export const identityStr3 = "mahiclsquy3nnoioxg3zhsci2vltdhmlsmdlbhbaglf5rjtq6c"
+export const Address3 = Address.fromString(identityStr3).toBuffer()
 
-export const taggedIdentity2 = tag(1000, Address2)
+export const taggedIdentity1 = tag(10000, Address1)
+export const taggedIdentity2 = tag(10000, Address2)
+export const taggedIdentity3 = tag(10000, Address2)
 export const taggedAccountSource = tag(
-  1000,
+  10000,
   Address.fromString(accountSource).toBuffer(),
 )
 

--- a/src/network/modules/types.ts
+++ b/src/network/modules/types.ts
@@ -10,7 +10,7 @@ export type LedgerSendParam = {
   symbol: string
 }
 
-export type EventTypeIndices = [number, number | [number, number]]
+export type EventTypeIndices = [number, number | EventTypeIndices]
 
 export enum EventType {
   send = "send",
@@ -84,4 +84,29 @@ export enum MultisigTransactionState {
   executedManually,
   withdrawn,
   expired,
+}
+
+export type Memo = string
+
+export enum BoundType {
+  unbounded = "unbounded",
+  inclusive = "inclusive",
+  exclusive = "exclusive",
+}
+
+export type Bound<T> = [] | [0, T] | [1, T]
+
+export type Range<T> = Map<0 | 1, Bound<T>>
+
+export interface RangeBound<T> {
+  boundType: BoundType
+  value: T
+}
+
+export type RangeBounds<T> = [RangeBound<T>?, RangeBound<T>?]
+
+export enum ListOrderType {
+  indeterminate = 0,
+  ascending = 1,
+  descending = 2,
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,15 @@
 // import crypto from "crypto"
 import { Message } from "../message"
 import { ManyError, SerializedManyError } from "../message/error"
-import { Network, NetworkModule } from "../network"
+import {
+  Bound,
+  BoundType,
+  Network,
+  NetworkModule,
+  Range,
+  RangeBounds,
+} from "../network"
+import { RangeType } from "../network/modules/events/events"
 
 export * from "./transactions"
 
@@ -39,4 +47,50 @@ export function throwOnErrorResponse(msg: Message) {
 
 export function makeRandomBytes(size = 32) {
   return crypto.getRandomValues(new Uint8Array(size))
+}
+
+export function setRangeBound<T>({
+  rangeMap,
+  rangeType,
+  boundType,
+  value,
+}: {
+  rangeMap: Range<T>
+  rangeType: RangeType
+  boundType: BoundType
+  value: unknown
+}) {
+  const rangeVal = rangeType === RangeType.lower ? 0 : 1
+  const boundVal = (
+    boundType !== BoundType.unbounded
+      ? [boundType === BoundType.inclusive ? 0 : 1, value]
+      : []
+  ) as Bound<T>
+  rangeMap.set(rangeVal, boundVal)
+}
+
+export function makeRange<T>(range: RangeBounds<T>) {
+  const rangeMap = new Map()
+  if (range && range.length) {
+    const [lower, upper] = range
+    if (lower) {
+      setRangeBound<Uint8Array>({
+        rangeMap,
+        rangeType: RangeType.lower,
+        ...lower,
+      })
+    }
+    if (upper) {
+      setRangeBound<Uint8Array>({
+        rangeMap,
+        rangeType: RangeType.upper,
+        ...upper,
+      })
+    }
+  }
+  return rangeMap
+}
+
+export function arrayBufferToHex(b: ArrayBuffer) {
+  return Buffer.from(b).toString("hex")
 }


### PR DESCRIPTION

<!-- Provide a general summary of changes in the title above. -->

## Description

<!-- Please describe your change in detail. -->
<!-- What is the current behavior and what is the new behavior? -->
- `Message.getPayload` was missing the decoders when doing `cbor.decode`
- tests needed to be fixed after adding `decoders`
## Testing

<!-- Please describe how you tested your changes. -->
<!-- Include details of your testing environment and the tests you ran. -->
- tests and mock data had to be adjusted

## Breaking Changes (if applicable)

<!-- Please describe any breaking changes and your plan to handle them. -->
<!-- A breaking change is a change to this module's API that might cause consumers to fail. -->
<!-- e.g. modifying required parameters, renaming a public method, changing a response type -->
- time is now provided in seconds instead of a js Date object as the cbor lib was doing by default whenever it came across tag of 1.

