### PR TITLE
adds fromHex to support creating identity with just seed

### DIFF
--- a/src/identity/ed25519/__tests__/ed25519-identity.test.ts
+++ b/src/identity/ed25519/__tests__/ed25519-identity.test.ts
@@ -23,10 +23,9 @@ describe("keys", () => {
     }).toThrow()
   })
 
-  test("fromSeed", async function () {
-    const seed =
-      "2690a9878f3e2bf5e7a5df08261334c2baec291b2fd28a12e2546a3b6a7d4ad9"
-    const alice = Ed25519KeyPairIdentity.fromSeed(seed)
+  test("fromHex", async function () {
+    const seed = "2690a9878f3e2bf5e7a5df08261334c2"
+    const alice = Ed25519KeyPairIdentity.fromHex(seed)
     const aliceAddress = (await alice.getAddress()).toString()
     expect(aliceAddress).toBe(
       "maeo2ob5e6mgaxr2lqg6muoqwuqz6j3t6wv3eig4wgymkouafh",

--- a/src/identity/ed25519/__tests__/ed25519-identity.test.ts
+++ b/src/identity/ed25519/__tests__/ed25519-identity.test.ts
@@ -7,7 +7,7 @@ describe("keys", () => {
     expect(seedWords.split(" ")).toHaveLength(12)
   })
 
-  test("fromSeedWords", async function () {
+  test("fromMnemonic", async function () {
     const seedWords = Ed25519KeyPairIdentity.getMnemonic()
     const badWords = "abandon abandon abandon"
 
@@ -21,6 +21,16 @@ describe("keys", () => {
     expect(() => {
       Ed25519KeyPairIdentity.fromMnemonic(badWords)
     }).toThrow()
+  })
+
+  test("fromSeed", async function () {
+    const seed =
+      "2690a9878f3e2bf5e7a5df08261334c2baec291b2fd28a12e2546a3b6a7d4ad9"
+    const alice = Ed25519KeyPairIdentity.fromSeed(seed)
+    const aliceAddress = (await alice.getAddress()).toString()
+    expect(aliceAddress).toBe(
+      "maeo2ob5e6mgaxr2lqg6muoqwuqz6j3t6wv3eig4wgymkouafh",
+    )
   })
 
   test("fromPem", async function () {

--- a/src/identity/ed25519/ed25519-key-pair-identity.ts
+++ b/src/identity/ed25519/ed25519-key-pair-identity.ts
@@ -30,7 +30,15 @@ export class Ed25519KeyPairIdentity extends PublicKeyIdentity {
       throw new Error("Invalid Mnemonic")
     }
     const seed = bip39.mnemonicToSeedSync(sanitized).slice(0, 32)
-    const keys = ed25519.generateKeyPair({ seed })
+    return Ed25519KeyPairIdentity.fromSeed(seed)
+  }
+
+  static fromSeed(seed: string | pki.ed25519.NativeBuffer) {
+    let _seed = seed?.slice(0, 32)
+    if (_seed.length !== 32) {
+      throw new Error("seed should have length of 32")
+    }
+    const keys = ed25519.generateKeyPair({ seed: _seed })
     return new Ed25519KeyPairIdentity(keys.publicKey, keys.privateKey)
   }
 
@@ -39,8 +47,7 @@ export class Ed25519KeyPairIdentity extends PublicKeyIdentity {
       const der = forge.pem.decode(pem)[0].body
       const asn1 = forge.asn1.fromDer(der.toString())
       const { privateKeyBytes } = ed25519.privateKeyFromAsn1(asn1)
-      const keys = ed25519.generateKeyPair({ seed: privateKeyBytes })
-      return new Ed25519KeyPairIdentity(keys.publicKey, keys.privateKey)
+      return Ed25519KeyPairIdentity.fromSeed(privateKeyBytes)
     } catch (e) {
       throw new Error("Invalid PEM")
     }

--- a/src/identity/ed25519/ed25519-key-pair-identity.ts
+++ b/src/identity/ed25519/ed25519-key-pair-identity.ts
@@ -30,15 +30,11 @@ export class Ed25519KeyPairIdentity extends PublicKeyIdentity {
       throw new Error("Invalid Mnemonic")
     }
     const seed = bip39.mnemonicToSeedSync(sanitized).slice(0, 32)
-    return Ed25519KeyPairIdentity.fromSeed(seed)
+    return Ed25519KeyPairIdentity.fromHex(seed)
   }
 
-  static fromSeed(seed: string | pki.ed25519.NativeBuffer) {
-    let _seed = seed?.slice(0, 32)
-    if (_seed.length !== 32) {
-      throw new Error("seed should have length of 32")
-    }
-    const keys = ed25519.generateKeyPair({ seed: _seed })
+  static fromHex(hex: string | pki.ed25519.NativeBuffer) {
+    const keys = ed25519.generateKeyPair({ seed: hex })
     return new Ed25519KeyPairIdentity(keys.publicKey, keys.privateKey)
   }
 
@@ -47,7 +43,7 @@ export class Ed25519KeyPairIdentity extends PublicKeyIdentity {
       const der = forge.pem.decode(pem)[0].body
       const asn1 = forge.asn1.fromDer(der.toString())
       const { privateKeyBytes } = ed25519.privateKeyFromAsn1(asn1)
-      return Ed25519KeyPairIdentity.fromSeed(privateKeyBytes)
+      return Ed25519KeyPairIdentity.fromHex(privateKeyBytes)
     } catch (e) {
       throw new Error("Invalid PEM")
     }


### PR DESCRIPTION
<!-- Provide a general summary of changes in the title above. -->

## Description

<!-- Please describe your change in detail. -->
<!-- What is the current behavior and what is the new behavior? -->

- adds `fromHex` method to `ed25519-key-pair-identity` to be able to create identities with a seed.
- example: we will use this in alberto to create identities via web3auth

## Related Issue

<!-- Pull Requests should relate to an open Issue. -->
<!-- If this PR fixes a bug or introduces a new feature, please create an Issue first. -->

Fixes https://github.com/liftedinit/albert/pull/92

## Testing

<!-- Please describe how you tested your changes. -->
<!-- Include details of your testing environment and the tests you ran. -->

- adds jest test