### PR TITLE
Add constants for the dataType field in toJSON serialization

### DIFF
--- a/src/identity/anonymous/anonymous-identity.ts
+++ b/src/identity/anonymous/anonymous-identity.ts
@@ -3,10 +3,7 @@ import { EMPTY } from "../../message/cose"
 import { Address } from "../address"
 
 export class AnonymousIdentity extends Identity {
-  // This constant string is from a previous mangling of the constructor name
-  // and should be used to maintained backward compatibility with existing
-  // local storages.
-  static dataType = 'r'
+  static dataType = 'anonymous'
 
   async sign() {
     return EMPTY

--- a/src/identity/anonymous/anonymous-identity.ts
+++ b/src/identity/anonymous/anonymous-identity.ts
@@ -3,6 +3,11 @@ import { EMPTY } from "../../message/cose"
 import { Address } from "../address"
 
 export class AnonymousIdentity extends Identity {
+  // This constant string is from a previous mangling of the constructor name
+  // and should be used to maintained backward compatibility with existing
+  // local storages.
+  static dataType = 'r'
+
   async sign() {
     return EMPTY
   }
@@ -15,6 +20,6 @@ export class AnonymousIdentity extends Identity {
   }
 
   toJSON(): { dataType: string } {
-    return { dataType: this.constructor.name }
+    return { dataType: (this.constructor as typeof Identity).dataType }
   }
 }

--- a/src/identity/ed25519/ed25519-key-pair-identity.ts
+++ b/src/identity/ed25519/ed25519-key-pair-identity.ts
@@ -2,10 +2,12 @@ import forge, { pki } from "node-forge"
 import * as bip39 from "bip39"
 import { CoseKey } from "../../message/cose"
 const ed25519 = pki.ed25519
-import { PublicKeyIdentity } from "../types"
+import {Identity, PublicKeyIdentity} from "../types"
 import { Address } from "../address"
 
 export class Ed25519KeyPairIdentity extends PublicKeyIdentity {
+  static dataType = 'ed25519'
+
   publicKey: ArrayBuffer
   protected privateKey: ArrayBuffer
 
@@ -75,7 +77,7 @@ export class Ed25519KeyPairIdentity extends PublicKeyIdentity {
     privateKey: ArrayBuffer
   } {
     return {
-      dataType: this.constructor.name,
+      dataType: (this.constructor as typeof Identity).dataType,
       publicKey: this.publicKey,
       privateKey: this.privateKey,
     }

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -13,6 +13,8 @@ export interface Verifier {
 }
 
 export abstract class Identity implements Signer, Verifier {
+  static dataType: string
+
   abstract getAddress(): Promise<Address>
   abstract toJSON(): unknown
   abstract sign(

--- a/src/identity/webauthn/webauthn-identity.ts
+++ b/src/identity/webauthn/webauthn-identity.ts
@@ -11,10 +11,7 @@ export class WebAuthnIdentity extends PublicKeyIdentity {
   rawId: ArrayBuffer
   cosePublicKey: ArrayBuffer
 
-  // This constant string is from a previous mangling of the constructor name
-  // and should be used to maintained backward compatibility with existing
-  // local storages.
-  static dataType = 'c'
+  static dataType = 'webauthn'
 
   constructor(cosePublicKey: ArrayBuffer, rawId: ArrayBuffer) {
     super()

--- a/src/identity/webauthn/webauthn-identity.ts
+++ b/src/identity/webauthn/webauthn-identity.ts
@@ -3,13 +3,18 @@ import { ONE_MINUTE } from "../../const"
 import { CoseKey, EMPTY } from "../../message/cose"
 import { makeRandomBytes } from "../../utils"
 import { Address } from "../address"
-import { PublicKeyIdentity } from "../types"
+import {Identity, PublicKeyIdentity} from "../types"
 const sha512 = require("js-sha512")
 
 export class WebAuthnIdentity extends PublicKeyIdentity {
   publicKey: ArrayBuffer
   rawId: ArrayBuffer
   cosePublicKey: ArrayBuffer
+
+  // This constant string is from a previous mangling of the constructor name
+  // and should be used to maintained backward compatibility with existing
+  // local storages.
+  static dataType = 'c'
 
   constructor(cosePublicKey: ArrayBuffer, rawId: ArrayBuffer) {
     super()
@@ -107,7 +112,7 @@ export class WebAuthnIdentity extends PublicKeyIdentity {
 
   toJSON(): { dataType: string; rawId: string; cosePublicKey: ArrayBuffer } {
     return {
-      dataType: this.constructor.name,
+      dataType: (this.constructor as typeof Identity).dataType,
       rawId: Buffer.from(this.rawId).toString("base64"),
       cosePublicKey: this.cosePublicKey,
     }


### PR DESCRIPTION
This makes sure that name mangling does not affect compatibility when deserializing and looking for data types.

ref https://github.com/liftedinit/lifted-ui/issues/7
