### PR TITLE
Fix the memo type

### DIFF
--- a/src/network/modules/account/__tests__/account.test.ts
+++ b/src/network/modules/account/__tests__/account.test.ts
@@ -94,7 +94,7 @@ describe("Account", () => {
       to: "m123",
       from: "m321",
       symbol: "m456",
-      memo: "this is a memo",
+      memo: ["this is a memo"],
       executeAutomatically: false,
       threshold: 3,
       expireInSecs: 3600,

--- a/src/network/modules/account/__tests__/account.test.ts
+++ b/src/network/modules/account/__tests__/account.test.ts
@@ -141,7 +141,7 @@ describe("Account", () => {
     )
     expect(res).toEqual({
       info: {
-        memo: "this is a memo",
+        memo: ["this is a memo"],
         transaction: {
           type: EventType.send,
           from: accountSource,
@@ -358,7 +358,7 @@ function makeMultisigInfoResponse({
     .set(5, executeAutomatically)
     .set(6, tag(1, expireDate))
     .set(8, txnState)
-    .set(9, "this is a memo")
+    .set(9, ["this is a memo"])
 }
 
 function makeAccountFeatures(): AccountFeature[] {

--- a/src/network/modules/events/events.ts
+++ b/src/network/modules/events/events.ts
@@ -11,6 +11,7 @@ import {
   EventType,
   EventTypeIndices,
   ListOrderType,
+  Memo,
   NetworkModule,
   RangeBounds,
 } from "../types"
@@ -92,13 +93,12 @@ export interface MultisigSetDefaultsEvent extends MultisigEvent {
 export interface MultisigSubmitEvent extends MultisigEvent {
   account: string
   executeAutomatically: boolean
-  memo: string
+  memo: Memo
   submitter: string
   threshold: number
   expireDate: number
   token: ArrayBuffer
   transaction: Omit<Event, "id" | "time"> | undefined
-  data?: CborMap
 }
 
 export type Event =

--- a/src/network/modules/types.ts
+++ b/src/network/modules/types.ts
@@ -86,7 +86,7 @@ export enum MultisigTransactionState {
   expired,
 }
 
-export type Memo = string
+export type Memo = (string | ArrayBuffer)[]
 
 export enum BoundType {
   unbounded = "unbounded",


### PR DESCRIPTION
Memo was updated to be an array of either string or bytestring.

rf. https://github.com/many-protocol/specification/pull/58
