### PR TITLE
fix: Memo type should be (string | ArrayBuffer)[]

### DIFF
--- a/src/network/modules/account/__tests__/account.test.ts
+++ b/src/network/modules/account/__tests__/account.test.ts
@@ -94,7 +94,7 @@ describe("Account", () => {
       to: "m123",
       from: "m321",
       symbol: "m456",
-      memo: "this is a memo",
+      memo: ["this is a memo"],
       executeAutomatically: false,
       threshold: 3,
       expireInSecs: 3600,

--- a/src/network/modules/account/__tests__/account.test.ts
+++ b/src/network/modules/account/__tests__/account.test.ts
@@ -141,7 +141,7 @@ describe("Account", () => {
     )
     expect(res).toEqual({
       info: {
-        memo: "this is a memo",
+        memo: ["this is a memo"],
         transaction: {
           type: EventType.send,
           from: accountSource,
@@ -358,7 +358,7 @@ function makeMultisigInfoResponse({
     .set(5, executeAutomatically)
     .set(6, tag(1, expireDate))
     .set(8, txnState)
-    .set(9, "this is a memo")
+    .set(9, ["this is a memo"])
 }
 
 function makeAccountFeatures(): AccountFeature[] {

--- a/src/network/modules/events/__tests__/data.ts
+++ b/src/network/modules/events/__tests__/data.ts
@@ -8,6 +8,7 @@ import {
   AccountRole,
   EventType,
   EventTypeIndices,
+  Memo,
 } from "../../types"
 import {
   accountSource,
@@ -89,12 +90,11 @@ function makeMultisigSubmitTxnResponse({
   txnTypeIndices = eventTypeNameToIndices.accountMultisigSubmit,
   submitter,
   accountSource,
-  memo = "",
+  memo = [""],
   submittedTxn,
   token = new Uint8Array(),
   threshold,
   executeAutomatically = false,
-  cborData,
   expireDate = new Date(new Date().getTime() + ONE_MINUTE).getTime(),
   time,
 }: {
@@ -102,12 +102,11 @@ function makeMultisigSubmitTxnResponse({
   txnTypeIndices?: EventTypeIndices
   submitter: string
   accountSource: string
-  memo?: string
+  memo?: Memo
   submittedTxn: Map<number, unknown>
   token?: ArrayBuffer
   threshold: number
   executeAutomatically: boolean
-  cborData?: Map<number, unknown>
   expireDate?: number
   time: number
 }) {
@@ -205,7 +204,7 @@ export const mockEventsListMultisigSubmitEventResponse =
       submitter: identityStr2,
       accountSource,
       threshold: 2,
-      memo: "this is a memo",
+      memo: ["this is a memo"],
       executeAutomatically: false,
       expireDate,
       submittedTxn: new Map().set(0, eventTypeNameToIndices.send).set(
@@ -228,7 +227,7 @@ export const expectedMockEventsListMultisigSubmitEventResponse = {
       type: EventType.accountMultisigSubmit,
       submitter: identityStr2,
       account: accountSource,
-      memo: "this is a memo",
+      memo: ["this is a memo"],
       token: new Uint8Array(),
       expireDate,
       threshold: 2,

--- a/src/network/modules/events/events.ts
+++ b/src/network/modules/events/events.ts
@@ -11,6 +11,7 @@ import {
   EventType,
   EventTypeIndices,
   ListOrderType,
+  Memo,
   NetworkModule,
   RangeBounds,
 } from "../types"
@@ -92,13 +93,12 @@ export interface MultisigSetDefaultsEvent extends MultisigEvent {
 export interface MultisigSubmitEvent extends MultisigEvent {
   account: string
   executeAutomatically: boolean
-  memo: string
+  memo: Memo
   submitter: string
   threshold: number
   expireDate: number
   token: ArrayBuffer
   transaction: Omit<Event, "id" | "time"> | undefined
-  data?: CborMap
 }
 
 export type Event =

--- a/src/network/modules/tokens/__tests__/tokens.test.ts
+++ b/src/network/modules/tokens/__tests__/tokens.test.ts
@@ -48,7 +48,7 @@ describe("Tokens", () => {
         name: "OurToken",
         symbol: "OTK",
         precision: 9,
-        memo: "Now decentralized!",
+        memo: ["Now decentralized!"],
       })
 
       expect(mockCall).toHaveBeenCalled()

--- a/src/network/modules/tokens/types.ts
+++ b/src/network/modules/tokens/types.ts
@@ -1,5 +1,5 @@
 import { Address } from "../../../identity"
-import { NetworkModule } from "../types"
+import { Memo, NetworkModule } from "../types"
 
 type LedgerAmount = BigInt
 type AttrIndex = number | [number, AttrIndex]
@@ -48,7 +48,7 @@ export interface TokensUpdateParam {
   symbol?: string
   precision?: number
   owner?: string | null
-  memo?: string
+  memo?: Memo
 }
 
 export interface TokensAddExtendedParam {

--- a/src/network/modules/types.ts
+++ b/src/network/modules/types.ts
@@ -86,7 +86,7 @@ export enum MultisigTransactionState {
   expired,
 }
 
-export type Memo = string
+export type Memo = (string | ArrayBuffer)[]
 
 export enum BoundType {
   unbounded = "unbounded",

--- a/src/utils/transactions/index.ts
+++ b/src/utils/transactions/index.ts
@@ -15,6 +15,7 @@ import {
   AccountMultisigArgument,
   MultisigSetDefaultsEvent,
   AddFeaturesEvent,
+  Memo,
 } from "../../network"
 
 export function makeLedgerSendParam({
@@ -293,6 +294,6 @@ async function makeMultisigSubmitEventData(
     threshold: eventData.get(6) as number,
     expireDate: eventData.get(7)?.value,
     executeAutomatically: eventData.get(8) as boolean,
-    memo: eventData.get(10) as string,
+    memo: eventData.get(10) as Memo,
   }
 }


### PR DESCRIPTION
Taking over @hansl 's PR: https://github.com/liftedinit/many-js/pull/95

Fixes https://github.com/liftedinit/alberto/issues/109