### PR TITLE
feat: illegal address

### DIFF
--- a/src/identity/address.ts
+++ b/src/identity/address.ts
@@ -3,6 +3,7 @@ import base32Encode from "base32-encode"
 import crc from "crc"
 
 export const ANON_IDENTITY = "maa"
+export const ILLEGAL_IDENTITY = "maiyg"
 export class Address {
   bytes: Uint8Array
 
@@ -12,6 +13,10 @@ export class Address {
 
   static anonymous(): Address {
     return new Address()
+  }
+
+  static illegal(): Address { 
+    return new Address(Buffer.from([0x02]))
   }
 
   static fromHex(hex: string): Address {
@@ -41,6 +46,10 @@ export class Address {
     return Buffer.compare(this.toBuffer(), Buffer.from([0x00])) === 0
   }
 
+  isIllegal(): boolean {
+    return Buffer.compare(this.toBuffer(), Buffer.from([0x02])) === 0
+  }
+
   toBuffer(): Buffer {
     return Buffer.from(this.bytes)
   }
@@ -48,6 +57,9 @@ export class Address {
   toString(): string {
     if (this.isAnonymous()) {
       return ANON_IDENTITY
+    }
+    if (this.isIllegal()) { 
+      return ILLEGAL_IDENTITY
     }
     const identity = this.toBuffer()
     const checksum = Buffer.allocUnsafe(3)
@@ -64,6 +76,9 @@ export class Address {
   toHex(): string {
     if (this.isAnonymous()) {
       return "00"
+    }
+    if (this.isIllegal()) {
+      return "02"
     }
     return Buffer.from(this.bytes).toString("hex")
   }

--- a/src/identity/address.ts
+++ b/src/identity/address.ts
@@ -27,6 +27,9 @@ export class Address {
     if (string === ANON_IDENTITY) {
       return new Address()
     }
+    if (string === ILLEGAL_IDENTITY) {
+      return new Address(Buffer.from([0x02]))
+    }
     const base32Address = string.slice(1, -2).toUpperCase()
     const base32Checksum = string.slice(-2).toUpperCase()
     const identity = base32Decode(base32Address, "RFC4648")

--- a/src/identity/identity.test.ts
+++ b/src/identity/identity.test.ts
@@ -21,6 +21,14 @@ describe("identity", () => {
     expect(anon).toStrictEqual(Address.fromString(anonStr))
   })
 
+  test("can read illegal", () => {
+    const illegal = new Address(Buffer.from([0x02]))
+    const illegalStr = illegal.toString()
+
+    expect(illegal.isIllegal()).toBe(true)
+    expect(illegal).toStrictEqual(Address.fromString(illegalStr))
+  })
+
   test("byte array conversion", () => {
     const anon = new Address()
     const alice = id(1)
@@ -73,4 +81,13 @@ describe("identity", () => {
     expect(alice).toStrictEqual(bob)
     expect(bob.withSubresource(2)).toStrictEqual(charlie)
   })
+
+  test("illegal text format", () => {   
+    const illegal = Address.fromString("maiyg")
+    const illegalHex = new Address(Buffer.from([0x02])).toString()
+
+    expect(illegal.isIllegal()).toBe(true)
+    expect(illegal.toString()).toStrictEqual(illegalHex)
+  })
+
 })

--- a/src/identity/identity.test.ts
+++ b/src/identity/identity.test.ts
@@ -84,10 +84,18 @@ describe("identity", () => {
 
   test("illegal text format", () => {   
     const illegal = Address.fromString("maiyg")
-    const illegalHex = new Address(Buffer.from([0x02])).toString()
+    const illegalStr = Address.illegal().toString()
 
     expect(illegal.isIllegal()).toBe(true)
-    expect(illegal.toString()).toStrictEqual(illegalHex)
+    expect(illegal.toString()).toStrictEqual(illegalStr)
+  })
+
+  test("illegal hex format", () => {
+    const illegal = Address.fromHex("02")
+    const illegalHex = new Address(Buffer.from([0x02])).toHex()
+
+    expect(illegal.isIllegal()).toBe(true)
+    expect(illegal.toHex()).toStrictEqual(illegalHex)
   })
 
 })


### PR DESCRIPTION
Adding support for the illegal address to the identity Address class. 

## Description

- Added static method for illegal address generation.
- Added isIllegal() method for testing if an Address matches a Buffer from the hex format 0x02.
- Extended toString() to return the illegal address "maiyg".
- Extended toHex() to return the illegal address in hex as "02".

Fixes # (issue)

## Testing
- Added tests for illegal address string and hex formats

## Breaking Changes (if applicable)
No breaking changes are to be expected. 

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the CONTRIBUTING guidelines for this project.
- [x] I have added or updated tests and they pass.
- [ ] I have added or updated documentation and it is accurate.
- [x] I have noted any breaking changes in this module or downstream modules.
