### PR TITLE
fix: workaround webpack 5 polyfill migration

### DIFF
--- a/src/identity/ed25519/ed25519-key-pair-identity.ts
+++ b/src/identity/ed25519/ed25519-key-pair-identity.ts
@@ -67,7 +67,9 @@ export class Ed25519KeyPairIdentity extends PublicKeyIdentity {
     c.set(3, -8) // alg: EdDSA
     c.set(-1, 6) // crv: Ed25519
     c.set(4, [2]) // key_ops: [verify]
-    c.set(-2, this.publicKey) // x: publicKey
+
+    // WARN: Buffer.from is required here to avoid array tagging by the cbor library
+    c.set(-2, Buffer.from(this.publicKey)) // x: publicKey
     return new CoseKey(c)
   }
 

--- a/src/message/cose.ts
+++ b/src/message/cose.ts
@@ -24,13 +24,13 @@ export class CoseMessage {
   protectedHeader: CborMap
   unprotectedHeader: CborMap
   content: CborMap
-  signature: ArrayBuffer
+  signature: Buffer
 
   constructor(
     protectedHeader: CborMap,
     unprotectedHeader: CborMap,
     content: CborMap,
-    signature: ArrayBuffer,
+    signature: Buffer, // WARN: Buffer required to avoid array tagging by cbor library.
   ) {
     this.protectedHeader = protectedHeader
     this.unprotectedHeader = unprotectedHeader
@@ -81,7 +81,7 @@ export class CoseMessage {
       protectedHeader,
       unprotectedHeader,
       content,
-      signature,
+      Buffer.from(signature), // WARN: Buffer required to avoid array tagging by cbor library.
     )
   }
 


### PR DESCRIPTION
The `cbor` library is tagging `ArrayBuffer` and `Uint8Array` with tag 64. Avoid that by using Node's `Buffer` structure instead.

This fix keeps `cbor` compatibility with the backend.